### PR TITLE
Wheel generation mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,6 @@ jobs:
                 output-dir: dist
                 config-file: "{package}/pyproject.toml"
 
-
             # Upload the artefact so they can be sent to pypi later on.
             - uses: actions/upload-artifact@v4
               with:
@@ -64,6 +63,11 @@ jobs:
             - name: List distribution directory content
               run: ls ./dist
 
+            # Upload the artefact so they can be sent to pypi later on.
+            - uses: actions/upload-artifact@v4
+              with:
+                name: dist
+                path: ./dist/*.*              
       
     merge:
       runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,11 +14,11 @@ jobs:
         strategy:
             matrix:
                 os: [
-                  ubuntu-22.04,
-                  ubuntu-20.04, 
-                  windows-2022, 
-                  windows-2019
-                  # macos-13, 
+                  # ubuntu-22.04,
+                  # ubuntu-20.04, 
+                  # windows-2022, 
+                  # windows-2019,
+                  macos-13
                   # macos-14
                 ]
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,12 @@ jobs:
         strategy:
             matrix:
                 os: [
-                  # ubuntu-22.04,
+                  ubuntu-22.04,
                   # ubuntu-20.04, 
-                  # windows-2022, 
+                  windows-2022, 
                   # windows-2019,
-                  macos-13
-                  # macos-14
+                  macos-13,
+                  macos-14
                 ]
     
         steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,18 @@ jobs:
                 config-file: "{package}/pyproject.toml"
 
 
+            # Upload the artefact so they can be sent to pypi later on.
+            - uses: actions/upload-artifact@v4
+              with:
+                name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+                path: ./dist/*.*
+    dist:
+      runs-on: "ubuntu-22.04"
+      needs: build
+      steps:
+            # Checkout code from GitHub
+            - uses: actions/checkout@v4
+
             - name: Build the standard distribution (Import Cython)
               run: python -m pip install Cython
 
@@ -52,14 +64,10 @@ jobs:
             - name: List distribution directory content
               run: ls ./dist
 
-            # Upload the artefact so they can be sent to pypi later on.
-            - uses: actions/upload-artifact@v4
-              with:
-                name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
-                path: ./dist/*.*
+      
     merge:
       runs-on: ubuntu-latest
-      needs: build
+      needs: dist
       steps:
         - name: Merge artifacts
           uses: actions/upload-artifact/merge@v4

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools.extension import Extension
 from setuptools.command.test import test as TestCommand
 from pathlib import Path
 
-version = '1.1.3'
+version = '1.1.4'
 
 """
 Note on using the setup.py:


### PR DESCRIPTION
Using cibuildwheel, the wheels are now generated for macos-13 and macos-14 in addition to Ubuntu and Windows.