### PR TITLE
37 bug vertex positions are not corretly rounded

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
             # Calling cibuildwheel. Most of the options are the default, but explicit is better than implicit.
             - name: Build wheels
-              uses: pypa/cibuildwheel@v2.19.1
+              uses: pypa/cibuildwheel@v2.21.3
               env:
                 CIBW_BEFORE_BUILD: python -m pip install Cython
                 CIBW_BUILD_VERBOSITY: 3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,8 @@ jobs:
         strategy:
             matrix:
                 os: [
-                  #ubuntu-22.04,
-                  ubuntu-latest,
-                  windows-2022, 
+                   ubuntu-22.04,
+                  # windows-2022, 
                   # macos-13,
                   # macos-14
                 ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,9 @@ jobs:
             matrix:
                 os: [
                   ubuntu-22.04,
-                  # ubuntu-20.04, 
                   windows-2022, 
-                  # windows-2019,
-                  macos-13,
-                  macos-14
+                  # macos-13,
+                  # macos-14
                 ]
     
         steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
             # Calling cibuildwheel. Most of the options are the default, but explicit is better than implicit.
             - name: Build wheels
-              uses: pypa/cibuildwheel@v2.21.3
+              uses: pypa/cibuildwheel@v2.21.2
               env:
                 CIBW_BEFORE_BUILD: python -m pip install Cython
                 CIBW_BUILD_VERBOSITY: 3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
         strategy:
             matrix:
                 os: [
-                   ubuntu-22.04,
-                  # windows-2022, 
-                  # macos-13,
-                  # macos-14
+                  ubuntu-22.04,
+                  windows-2022, 
+                  macos-13,
+                  macos-14
                 ]
     
         steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
                   ubuntu-22.04,
                   windows-2022, 
                   macos-13,
-                  macos-14
+                  # macos-14
                 ]
     
         steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
             # Calling cibuildwheel. Most of the options are the default, but explicit is better than implicit.
             - name: Build wheels
-              uses: pypa/cibuildwheel@v2.21.2
+              uses: pypa/cibuildwheel@v2.19.2
               env:
                 CIBW_BEFORE_BUILD: python -m pip install Cython
                 CIBW_BUILD_VERBOSITY: 3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
                 CIBW_BEFORE_BUILD: python -m pip install Cython
                 CIBW_BUILD_VERBOSITY: 3
                 CIBW_DEBUG_TRACEBACK: TRUE
-                CIBW_SKIP: pp3*
+                CIBW_SKIP: "pp3* cp38-macosx_arm64"
               with:
                 package-dir: .
                 output-dir: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
                 CIBW_BEFORE_BUILD: python -m pip install Cython
                 CIBW_BUILD_VERBOSITY: 3
                 CIBW_DEBUG_TRACEBACK: TRUE
-                CIBW_SKIP: "pp3* cp38-macosx_arm64 cp39-macosx_arm64"
+                CIBW_SKIP: "pp3*"
               with:
                 package-dir: .
                 output-dir: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,7 @@ jobs:
                 os: [
                   ubuntu-22.04,
                   windows-2022, 
-                  macos-13,
-                  # macos-14
+                  macos-13
                 ]
     
         steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
             matrix:
                 os: [
                   #ubuntu-22.04,
+                  ubuntu-latest,
                   windows-2022, 
                   # macos-13,
                   # macos-14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
                 CIBW_BEFORE_BUILD: python -m pip install Cython
                 CIBW_BUILD_VERBOSITY: 3
                 CIBW_DEBUG_TRACEBACK: TRUE
-                CIBW_SKIP: "pp3* cp38-macosx_arm64"
+                CIBW_SKIP: "pp3* cp38-macosx_arm64 cp39-macosx_arm64"
               with:
                 package-dir: .
                 output-dir: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
             # Calling cibuildwheel. Most of the options are the default, but explicit is better than implicit.
             - name: Build wheels
-              uses: pypa/cibuildwheel@v2.19.2
+              uses: pypa/cibuildwheel@v2.21.3
               env:
                 CIBW_BEFORE_BUILD: python -m pip install Cython
                 CIBW_BUILD_VERBOSITY: 3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
                 CIBW_BEFORE_BUILD: python -m pip install Cython
                 CIBW_BUILD_VERBOSITY: 3
                 CIBW_DEBUG_TRACEBACK: TRUE
+                CIBW_SKIP: pp3*
               with:
                 package-dir: .
                 output-dir: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         strategy:
             matrix:
                 os: [
-                  ubuntu-22.04,
+                  #ubuntu-22.04,
                   windows-2022, 
                   # macos-13,
                   # macos-14

--- a/pyvoronoi/pyvoronoi.pyx
+++ b/pyvoronoi/pyvoronoi.pyx
@@ -513,7 +513,7 @@ cdef class Pyvoronoi:
         return Point(self._to_voronoi_int(py_point[0]), self._to_voronoi_int(py_point[1]))
 
     cdef int _to_voronoi_int(self, val):
-        return val * self.SCALING_FACTOR
+        return round(val * self.SCALING_FACTOR)
 
     cdef double _to_voronoi_double(self, val):
         return val * <double>self.SCALING_FACTOR

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,6 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules"
     ],
     ext_modules=[ext],
-    tests_require=['pytest'],
     cmdclass={
         'build_ext': build_ext_subclass
     },   

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools.extension import Extension
 from setuptools.command.test import test as TestCommand
 from pathlib import Path
 
-version = '1.1.4'
+version = '1.1.5'
 
 """
 Note on using the setup.py:

--- a/setup.py
+++ b/setup.py
@@ -43,28 +43,6 @@ ext = Extension("pyvoronoi",
 
 
 # This command has been borrowed from
-# http://pytest.org/latest/goodpractises.html
-class PyTest(TestCommand):
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
-
-
-# This command has been borrowed from
 # http://www.pydanny.com/python-dot-py-tricks.html
 
 if sys.argv[-1] == 'tag':
@@ -119,8 +97,6 @@ setup(
     ext_modules=[ext],
     tests_require=['pytest'],
     cmdclass={
-        'test': PyTest,
         'build_ext': build_ext_subclass
-    },
-        
+    },   
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 import os
 from setuptools import setup
 from setuptools.extension import Extension
-from setuptools.command.test import test as TestCommand
 from pathlib import Path
 
 version = '1.1.5'

--- a/tests/test_pyvoronoi.py
+++ b/tests/test_pyvoronoi.py
@@ -52,6 +52,19 @@ class TestPyvoronoiAdd(TestCase):
         pv.Construct()
         self.assertRaises(pyvoronoi.VoronoiException, pv.AddPoint, [0, 0])
 
+    def test_add_segment_rounding(self):
+        factor = 10
+        segment = [[0.59, 1.09], [0, 2]]
+        pv = pyvoronoi.Pyvoronoi(factor)
+        pv.AddSegment(segment)
+        segments = pv.GetSegments()
+        print(segments)
+        self.assertTrue(len(segments) == 1)
+        self.assertTrue(segments[0] == [
+            [round(segment[0][0] * factor), round(segment[0][1] * factor)],
+            [segment[1][0] * factor, segment[1][1] * factor],
+        ])
+
 class TestPyvoronoiConstruct(TestCase):
     def test_square(self):
         pv = pyvoronoi.Pyvoronoi(1)


### PR DESCRIPTION
Fix  #37. Added rounding when multiplying input point coordinates using the scale factor.

I had to upgrade Cibuildwheels to support Python 3.13. The tradeoff is that cibuildwheel is complaining about building wheels on MacOS14, but compiles everywhere else. Therefore, I am pushing this code as version 1.1.5. I will work on resolving that other issue separately.

