### PR TITLE
Use instance variables for Pyvoronoi cython code

### DIFF
--- a/pyvoronoi/pyvoronoi.pyx
+++ b/pyvoronoi/pyvoronoi.pyx
@@ -143,8 +143,8 @@ class Cell:
     contains_segment = False
     is_open = False
 
-    vertices = []
-    edges = []
+    vertices = None
+    edges = None
 
     source_category = None
 
@@ -211,11 +211,8 @@ cdef class Pyvoronoi:
     cdef VoronoiDiagram *thisptr
     cdef int constructed
 
-    inputPoints = []
-    inputSegments = []
-    outputEdges = []
-    outputVertices = []
-    outputCells = []
+    cdef readonly list inputPoints
+    cdef readonly list inputSegments
 
     cdef public int SCALING_FACTOR
 
@@ -231,8 +228,8 @@ cdef class Pyvoronoi:
         else:
             self.SCALING_FACTOR = 1
 
-        del self.inputPoints[:]
-        del self.inputSegments[:]
+        self.inputPoints = []
+        self.inputSegments = []
 
     def __dealloc__(self):
         log_action("Deleting the VoronoiDiagram instance")

--- a/tests/test_pyvoronoi.py
+++ b/tests/test_pyvoronoi.py
@@ -253,6 +253,24 @@ class TestPyvoronoiConstruct(TestCase):
         with self.assertRaises(ValueError):
             pv.DiscretizeCurvedEdge(2, -1)
 
+    def test_objects_dont_share_data(self):
+        pv = pyvoronoi.Pyvoronoi(1)
+        pv.AddPoint([5, 5])
+        pv.AddSegment([[0, 0], [0, 10]])
+
+        pv2 = pyvoronoi.Pyvoronoi(1)
+        pv2.AddPoint([9, 9])
+        pv2.AddSegment([[1, 1], [1, 9]])
+
+        pv.Construct()
+        pv2.Construct()
+
+        self.assertEqual([[5, 5]], pv.inputPoints)
+        self.assertEqual([[[0, 0], [0, 10]]], pv.inputSegments)
+        self.assertEqual([[9, 9]], pv2.inputPoints)
+        self.assertEqual([[[1, 1], [1, 9]]], pv2.inputSegments)
+
+
 def run_tests():
     main()
 


### PR DESCRIPTION
This avoids their values accidentally being shared between any concurrent use of Pyvornoi, even without threads.

With test.

Fixes #47