### PR TITLE
Mark Construct nogil so it can operate in parallel

### DIFF
--- a/pyvoronoi/pyvoronoi.pyx
+++ b/pyvoronoi/pyvoronoi.pyx
@@ -94,7 +94,7 @@ cdef extern from "voronoi.hpp":
         VoronoiDiagram()
         void AddPoint(Point p)
         void AddSegment(Segment s)
-        void Construct()
+        void Construct() nogil
         vector[Point] GetPoints()
         vector[Segment] GetSegments()
 
@@ -268,8 +268,8 @@ cdef class Pyvoronoi:
             raise VoronoiException('Construct() has already been called')
 
         self.constructed = 1
-
-        self.thisptr.Construct()
+        with nogil:
+            self.thisptr.Construct()
 
         self.thisptr.MapVertexIndexes()
         self.thisptr.MapEdgeIndexes()


### PR DESCRIPTION
Since the values are already marshalled to C++ structures, this should be safe to drop the GIL.  More methods could be added to this as well but I feel there's some upcoming refactor for #31/#32 that I'd let shake out first.