### PR TITLE
Build aarch64 wheels in CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
               uses: pypa/cibuildwheel@v2.21.3
               env:
                 CIBW_BEFORE_BUILD: python -m pip install Cython
+                CIBW_ARCHS_LINUX: "x86_64 aarch64"
                 CIBW_BUILD_VERBOSITY: 3
                 CIBW_DEBUG_TRACEBACK: TRUE
                 CIBW_SKIP: "pp3*"


### PR DESCRIPTION
We use arm64 images and found installs weren’t working, unless we built wheels locally! This change ensures releases publish aarch64 wheels automatically, which makes installs much friendlier anyone else on arm64.