### PR TITLE
Add ARM runner, and change build target to native

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
             matrix:
                 os: [
                   ubuntu-22.04,
+                  ubuntu-24.04-arm,
                   windows-2022,
                   macos-14
                 ]
@@ -32,7 +33,7 @@ jobs:
               uses: pypa/cibuildwheel@v2.21.3
               env:
                 CIBW_BEFORE_BUILD: python -m pip install Cython
-                CIBW_ARCHS_LINUX: "x86_64 aarch64"
+                CIBW_ARCHS_LINUX: "auto"
                 CIBW_BUILD_VERBOSITY: 3
                 CIBW_DEBUG_TRACEBACK: TRUE
                 CIBW_SKIP: "pp3*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
               uses: pypa/cibuildwheel@v2.21.3
               env:
                 CIBW_BEFORE_BUILD: python -m pip install Cython
-                CIBW_ARCHS_LINUX: "auto"
+                CIBW_ARCHS_LINUX: "native"
                 CIBW_BUILD_VERBOSITY: 3
                 CIBW_DEBUG_TRACEBACK: TRUE
                 CIBW_SKIP: "pp3*"


### PR DESCRIPTION
This fix uses an ARM runner to build the ARM image, therefore not requiring emulation. This should fix the timeout issues @fabanc was seeing in issue #81 - and result in a more reliable build, since each architecture builds for it's own.

The ARM build went from 6+ hours (timed out) with QEMU emulation to 13 minutes on a native runner. The whole pipeline completes in under 25 minutes.

===

AI Disclosure: Claude Code helped investigate and test this. Human verified.

===

### Testing plan
- [x] Build the wheel in github: https://github.com/hanneshdc/pyvoronoi/actions/runs/22430159598
- [x] Test resulting binary: Done. Downloaded the CI-built ARM wheel and installed it in a docker container. Called voronoi function and it successfully constructed a diagram with 3 vertices, 14 edges and 5 cells. Did not verify the exact output, but I believe this smoke test is enough to get confidence that the ARM build worked.