### PR TITLE
77 no release on pypi for version 314

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 
             # Calling cibuildwheel. Most of the options are the default, but explicit is better than implicit.
             - name: Build wheels
-              uses: pypa/cibuildwheel@v2.21.3
+              uses: pypa/cibuildwheel@v3.3.1
               env:
                 CIBW_BEFORE_BUILD: python -m pip install Cython
                 CIBW_ARCHS_LINUX: "x86_64"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,11 +14,9 @@ jobs:
         strategy:
             matrix:
                 os: [
-                  windows-2025,
+                  windows-2022,
                   ubuntu-22.04,
-                  ubuntu-24.04,
-                  macos-14,
-                  macos-15,
+                  macos-14
                 ]
     
         steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
                 CIBW_BUILD_VERBOSITY: 3
                 CIBW_DEBUG_TRACEBACK: TRUE
                 CIBW_SKIP: "pp3*"
-                CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"
+                CIBW_PROJECT_REQUIRES_PYTHON: ">=3.10"
               with:
                 package-dir: .
                 output-dir: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,11 @@ jobs:
         strategy:
             matrix:
                 os: [
+                  windows-2025,
                   ubuntu-22.04,
-                  windows-2022,
-                  macos-14
+                  ubuntu-24.04,
+                  macos-14,
+                  macos-15,
                 ]
     
         steps:
@@ -32,7 +34,7 @@ jobs:
               uses: pypa/cibuildwheel@v2.21.3
               env:
                 CIBW_BEFORE_BUILD: python -m pip install Cython
-                CIBW_ARCHS_LINUX: "x86_64 aarch64"
+                CIBW_ARCHS_LINUX: "x86_64"
                 CIBW_BUILD_VERBOSITY: 3
                 CIBW_DEBUG_TRACEBACK: TRUE
                 CIBW_SKIP: "pp3*"

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -38,7 +38,7 @@ jobs:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
     needs:
-      - call-build
+      - publish-to-testpypi
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -34,6 +34,7 @@ jobs:
       with:
         repository-url: https://test.pypi.org/legacy/
         verbose: true
+        skip-existing: true
 
   publish-to-pypi:
     name: >-
@@ -57,6 +58,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         verbose: true
+        skip-existing: true
 
   # github-release:
   #   name: >-

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -32,7 +32,8 @@ jobs:
     - name: Publish distribution 📦 to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        repository-url: https://test.pypi.org/legacy/  
+        repository-url: https://test.pypi.org/legacy/
+        verbose: true
 
   publish-to-pypi:
     name: >-
@@ -54,6 +55,8 @@ jobs:
         path: dist/
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        verbose: true
 
   # github-release:
   #   name: >-

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ The documentation for Pyvoronoi is available [here](https://pyvoronoi.readthedoc
 The documentation is built with Sphinx. See the `docs` folder and the file `requirements.txt` to check the requirements if you want to build it locally .
 
 ## Change log
- * 1.2.6: Support for Python 3.14. Added wheels for macos-15. Removed wheel support for macos-13.
+ * 1.2.7: Support for Python 3.14. Removed wheel support for macos-13.
+ * 1.2.6: (skipped)
  * 1.2.5: (skipped)
  * 1.2.4: Removed C++ warning during compile time by addressing possible data loss when switching between integer types.
  * 1.2.3: (skipped)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ The documentation for Pyvoronoi is available [here](https://pyvoronoi.readthedoc
 The documentation is built with Sphinx. See the `docs` folder and the file `requirements.txt` to check the requirements if you want to build it locally .
 
 ## Change log
- * 1.2.5: Support for Python 3.14. Added wheels for macos-15. Removed wheel support for macos-13. 
+ * 1.2.6: Support for Python 3.14. Added wheels for macos-15. Removed wheel support for macos-13.
+ * 1.2.5: (skipped)
  * 1.2.4: Removed C++ warning during compile time by addressing possible data loss when switching between integer types.
  * 1.2.3: (skipped)
  * 1.2.2: Added API documentation using Sphynx and Read The Doc theme.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The documentation for Pyvoronoi is available [here](https://pyvoronoi.readthedoc
 The documentation is built with Sphinx. See the `docs` folder and the file `requirements.txt` to check the requirements if you want to build it locally .
 
 ## Change log
+ * 1.2.5: Support for Python 3.14. Added wheels for macos-15. Removed wheel support for macos-13. 
  * 1.2.4: Removed C++ warning during compile time by addressing possible data loss when switching between integer types.
  * 1.2.3: (skipped)
  * 1.2.2: Added API documentation using Sphynx and Read The Doc theme.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from setuptools.extension import Extension
 from pathlib import Path
 
-version = '1.2.6'
+version = '1.2.7'
 
 """
 Note on using the setup.py:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from setuptools.extension import Extension
 from pathlib import Path
 
-version = '1.2.5'
+version = '1.2.6'
 
 """
 Note on using the setup.py:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from setuptools.extension import Extension
 from pathlib import Path
 
-version = '1.2.4'
+version = '1.2.5'
 
 """
 Note on using the setup.py:


### PR DESCRIPTION
Added wheels for Python 3.14. Fixes #77. In the same token a few update have happened.

1. cibuildwheel was updated from v2.21.3 to v3.3.1. An update was required to support Python 3.14
2. minimum supported python version updated from 3.8  to 3.10 to match Python's official support.